### PR TITLE
chore: add httpx dependency for tests

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,5 @@ black
 isort
 flake8
 mypy
+httpx<0.28
 


### PR DESCRIPTION
## Summary
- ensure FastAPI TestClient has httpx available

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend`
- `pre-commit run --files backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a8cc84dffc832c92ef01cad68e6150